### PR TITLE
Uptated react-scripts version to 3.4.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "react-markdown": "^4.3.1",
     "react-moment": "^0.9.7",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "3.3.0"
+    "react-scripts": "^3.4.0"
   },
   "scripts": {
     "develop": "react-scripts start",


### PR DESCRIPTION
Just updated the version of react-scripts module in frontend folder's package.json file. This was needed because of the error I have struggled. Have added it as an issue in the repo and we found one of the solutions which means updating the version to "^3.4.0". [The closed issue with solution](https://github.com/strapi/strapi-starter-react-blog/issues/7)